### PR TITLE
KYAN - Added ability to specify a custom route name

### DIFF
--- a/grape_documenter.gemspec
+++ b/grape_documenter.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'redcarpet'
-  gem.add_development_dependency 'rspec'
+  gem.add_development_dependency 'rspec', '< 3.0.0'
   gem.add_development_dependency 'ruby2ruby'
   gem.add_development_dependency 'simplecov'
   gem.add_development_dependency 'yard'

--- a/lib/grape_documenter/generator.rb
+++ b/lib/grape_documenter/generator.rb
@@ -82,8 +82,15 @@ module GrapeDocumenter
       instance_variable_set("@#{version}_routes", @api_class.routes.select { |r| r.route_version == version })
     end
 
+    def endpoint_action(route)
+      route_end_point = @api_class.endpoints.select { |endpoint| endpoint.routes.include? route }
+      route_end_point.first.options[:route_options][:action]
+    end
+
     def routes_for_version_and_namespace(version, namespace)
-      routes_for_version(version).select { |r| normalize_route_namespace(r) == namespace }.map{|r| RouteDoc.new(r, :mounted_path => @mounted_path)}
+      routes_for_version(version).select { |r| normalize_route_namespace(r) == namespace }.map do |r|
+        RouteDoc.new(r, :mounted_path => @mounted_path, :action => endpoint_action(r))
+      end
     end
 
     def titleize(string)

--- a/lib/grape_documenter/route_doc.rb
+++ b/lib/grape_documenter/route_doc.rb
@@ -7,6 +7,7 @@ module GrapeDocumenter
     def initialize(route, options = {})
       @route = route
       @mounted_path = options[:mounted_path] || ''
+      @action = options[:action] || ''
     end
 
     def http_method
@@ -29,6 +30,10 @@ module GrapeDocumenter
       @route.route_optional_params
     end
 
+    def action_params
+      @action
+    end
+
     def inferred_title
       "To #{inferred_action} #{inferred_resource}"
     end
@@ -36,7 +41,7 @@ module GrapeDocumenter
     def inferred_rails_action
       case http_method
       when 'GET'
-        inferred_singular? ? 'show' : 'index'
+        inferred_action_from_params
       when 'PUT'
         'update'
       when 'POST'
@@ -75,6 +80,11 @@ module GrapeDocumenter
 
     def inferred_singular?
       path.include?(':id') || http_method == 'POST'
+    end
+
+    def inferred_action_from_params
+      return action_params unless action_params.blank?
+      inferred_singular? ? 'show' : 'index'
     end
 
     def path_without_format

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -38,6 +38,19 @@ describe GrapeDocumenter::Generator do
               routes.first.path.should == '/:version/user'
             end
           end
+
+          describe 'path' do
+            it 'returns /users' do
+              routes.first.path.should == '/:version/user'
+            end
+          end
+
+          describe 'action_params' do
+            it 'returns /users' do
+              allow(subject).to receive(:endpoint_action).and_return 'custom_action'
+              routes.first.action_params.should == 'custom_action'
+            end
+          end
         end
 
         describe 'show' do

--- a/spec/route_doc_spec.rb
+++ b/spec/route_doc_spec.rb
@@ -229,5 +229,13 @@ describe GrapeDocumenter::RouteDoc do
         subject.inferred_rails_action.should == 'destroy'
       end
     end
+
+    context 'when custom route' do
+      subject { described_class.new mock_route, :action => 'custom_route' }
+
+      it 'returns custom route' do
+        subject.inferred_rails_action.should == 'custom_route'
+      end
+    end
   end
 end


### PR DESCRIPTION
Whilst using the grape_documenter to document some new API endpoints we found that it did not work correctly for some custom routes. This patch allows you to modify the result of `inferred_rails_action` by added a hash like `:action => 'custom_route'` alongside the params hash, passed in with the endpoint description. Eg:

```
  desc 'Creates a new ledger account', {
    :params => {
      'ledger_account[included_in_chart]' => {
        :type => 'boolean',
        :desc => 'Boolean that marks the Ledger Account as included.'
      }
    },
    :action => 'custom_action'
  }
```

If no action hash is specified then original behaviour is unaffected.
